### PR TITLE
Fix escaped connect arguments parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/rs/zerolog v1.31.0
-	github.com/seternate/go-lanty v0.1.0-beta
+	github.com/seternate/go-lanty v0.1.0-beta.0.20240505140903-1ecd9b6d4b5d
 	golang.design/x/clipboard v0.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seternate/go-lanty v0.1.0-beta h1:gpclCPCz5H2hmNeyHrLxVe1sP3d/5SzKSEzG+SHWgas=
 github.com/seternate/go-lanty v0.1.0-beta/go.mod h1:1mxIN82SScfhtjQYzjUSFSz3ArrgOIsHBSjHl54BaMc=
+github.com/seternate/go-lanty v0.1.0-beta.0.20240505140903-1ecd9b6d4b5d h1:Fy0j73ur2t4zuSomJBEDJjr71PxFC4SF0sbM/YN5t3k=
+github.com/seternate/go-lanty v0.1.0-beta.0.20240505140903-1ecd9b6d4b5d/go.mod h1:1mxIN82SScfhtjQYzjUSFSz3ArrgOIsHBSjHl54BaMc=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=


### PR DESCRIPTION
Update go-lanty dependecy to fix the wrong connect argument escape parsing. With this games like Teeworlds can now use the command-line argument to directly connect to a server.

Fixes https://github.com/seternate/go-lanty-client/issues/29