### PR TITLE
Open all found game executables in file explorer.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/rs/zerolog v1.31.0
-	github.com/seternate/go-lanty v0.1.0-beta.0.20240505140903-1ecd9b6d4b5d
+	github.com/seternate/go-lanty v0.1.0-beta.0.20240517150350-28bf44a66830
 	golang.design/x/clipboard v0.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ github.com/seternate/go-lanty v0.1.0-beta h1:gpclCPCz5H2hmNeyHrLxVe1sP3d/5SzKSEz
 github.com/seternate/go-lanty v0.1.0-beta/go.mod h1:1mxIN82SScfhtjQYzjUSFSz3ArrgOIsHBSjHl54BaMc=
 github.com/seternate/go-lanty v0.1.0-beta.0.20240505140903-1ecd9b6d4b5d h1:Fy0j73ur2t4zuSomJBEDJjr71PxFC4SF0sbM/YN5t3k=
 github.com/seternate/go-lanty v0.1.0-beta.0.20240505140903-1ecd9b6d4b5d/go.mod h1:1mxIN82SScfhtjQYzjUSFSz3ArrgOIsHBSjHl54BaMc=
+github.com/seternate/go-lanty v0.1.0-beta.0.20240517150350-28bf44a66830 h1:ba5WOpu0ckeJivCbMrRHRg09vLA8pPSqI9WxbTzGGbU=
+github.com/seternate/go-lanty v0.1.0-beta.0.20240517150350-28bf44a66830/go.mod h1:1mxIN82SScfhtjQYzjUSFSz3ArrgOIsHBSjHl54BaMc=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/pkg/widget/gametile.go
+++ b/pkg/widget/gametile.go
@@ -175,7 +175,7 @@ func (widget *GameTile) updatePlayAndOpenButtonStatus() {
 	if runtime.GOOS != "windows" {
 		return
 	}
-	paths, err := filesystem.SearchFileByName(widget.controller.Settings.Settings().GameDirectory, widget.game.Client.Executable, 2)
+	paths, err := filesystem.SearchFilesBreadthFirst(widget.controller.Settings.Settings().GameDirectory, widget.game.Client.Executable, 3, 1)
 	if (err != nil || len(paths) == 0) && !widget.buttons["play"].Disabled() {
 		widget.buttons["play"].Disable()
 		widget.buttons["open"].Disable()


### PR DESCRIPTION
All game executables that are found within a depth of 3 in a breath-first search at the given game-directory are opened in the file explorer.

This is useful to find multiple copies of the same game inside the game-directory.

Fixes https://github.com/seternate/go-lanty-client/issues/22