### PR TITLE
Remove flag for logfile and always log to file

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -26,7 +26,12 @@ func main() {
 	signalCtx, cancelSignalCtx := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancelSignalCtx()
 
-	logconfig := logging.Config{ConsoleLoggingEnabled: true}
+	logconfig := logging.Config{
+		ConsoleLoggingEnabled: true,
+		FileLoggingEnabled:    true,
+		Filename:              "lanty.log",
+		Directory:             "log",
+	}
 	parseFlags(&logconfig)
 	log.Logger = logging.Configure(logconfig)
 
@@ -68,9 +73,6 @@ func getApplicationTitle() string {
 
 func parseFlags(config *logging.Config) {
 	flag.StringVar(&config.LogLevel, "loglevel", "info", "Sets the log level")
-	flag.BoolVar(&config.FileLoggingEnabled, "logenablefile", false, "Enables logging to file")
-	flag.StringVar(&config.Filename, "logfile", "lanty.log", "Sets the log filename")
-	flag.StringVar(&config.Directory, "logdir", "log", "Sets the log directory")
 	flag.IntVar(&config.MaxBackups, "logbackups", 0, "Sets the number of old logs to remain")
 	flag.IntVar(&config.MaxSize, "logfilesize", 10, "Sets the size of the logs before rotating to new file")
 	flag.IntVar(&config.MaxAge, "logage", 0, "Sets the maximum number of days to retain old logs")


### PR DESCRIPTION
The flag to disable/enable file logging was removed, because a windows application can not log to stdout on windows. Therefore it is necessary to always log to a logfile in order to retrieve any logs. This is the reason the logfile flag was removed and it is always logged to file.

Fixes: https://github.com/seternate/go-lanty-client/issues/9