### PR TITLE
Fix startup if scheme is missing in server URL

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -37,11 +37,16 @@ func NewController(ctx context.Context) *Controller {
 	if err != nil {
 		log.Fatal().Err(err).Send()
 	}
-	url, err := url.Parse(settings.ServerURL)
+
+	u, err := url.Parse(settings.ServerURL)
+	if len(u.Host) == 0 {
+		u, err = url.Parse("http://" + settings.ServerURL)
+	}
 	if err != nil {
 		log.Fatal().Err(err).Str("url", settings.ServerURL).Msg("failed to parse server URL")
 	}
-	client := api.NewClient(url, timeout)
+
+	client := api.NewClient(u, timeout)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to create API client")
 	}


### PR DESCRIPTION
If the scheme in the server URL is missing 'http' is added as default scheme and the url is parsed again. With this behaviour the user does not need to enter the scheme if it would be 'http'.

Fixes: https://github.com/seternate/go-lanty-client/issues/4