### PR TITLE
Add a dialog for game-directory in SettingsBrowser

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -49,7 +49,7 @@ func main() {
 
 	app := app.New()
 	window := app.NewWindow(getApplicationTitle())
-	lanty := widget.NewLanty(controller)
+	lanty := widget.NewLanty(controller, window)
 	window.SetContent(lanty)
 	window.SetPadded(false)
 	window.Resize(fyne.NewSize(1024, 600))

--- a/pkg/widget/lanty.go
+++ b/pkg/widget/lanty.go
@@ -33,12 +33,12 @@ type Lanty struct {
 	statusupdate chan struct{}
 }
 
-func NewLanty(controller *controller.Controller) *Lanty {
+func NewLanty(controller *controller.Controller, window fyne.Window) *Lanty {
 	gamebrowser := NewGameBrowser(controller)
 	startserver := NewStartServer(controller)
 	downloadbrowser := NewDownloadBrowser(controller)
 	userbrowser := NewUserBrowser(controller)
-	settingsbrowser := NewSettingsBrowser(controller)
+	settingsbrowser := NewSettingsBrowser(controller, window)
 
 	lanty := &Lanty{
 		controller:      controller,

--- a/pkg/widget/settingbrowser.go
+++ b/pkg/widget/settingbrowser.go
@@ -6,58 +6,65 @@ import (
 	"time"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/data/binding"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/storage"
+	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
+	"github.com/rs/zerolog/log"
 	"github.com/seternate/go-lanty-client/pkg/controller"
 )
 
 type SettingsBrowser struct {
 	widget.BaseWidget
 
-	controller    *controller.Controller
-	form          *Form
-	serverurl     binding.String
-	gamedirectory binding.String
-	username      binding.String
+	controller *controller.Controller
+	window     fyne.Window
+	form       *Form
+
+	serverurl     *widget.Entry
+	gamedirectory *widget.Entry
+	username      *widget.Entry
+
+	settingschanged chan struct{}
 }
 
-func NewSettingsBrowser(controller *controller.Controller) (settingsbrowser *SettingsBrowser) {
+func NewSettingsBrowser(controller *controller.Controller, window fyne.Window) (settingsbrowser *SettingsBrowser) {
 	settingsbrowser = &SettingsBrowser{
-		controller: controller,
-		form:       NewForm(),
+		controller:      controller,
+		window:          window,
+		form:            NewForm(),
+		serverurl:       widget.NewEntry(),
+		gamedirectory:   widget.NewEntry(),
+		username:        widget.NewEntry(),
+		settingschanged: make(chan struct{}, 50),
 	}
 	settingsbrowser.ExtendBaseWidget(settingsbrowser)
 
-	serverurlbind := binding.NewString()
-	serverurlbind.Set(controller.Settings.Settings().ServerURL)
-	serverurlentry := widget.NewEntryWithData(serverurlbind)
-	settingsbrowser.form.AppendItem(NewFormItem("Server URL", serverurlentry))
+	settingsbrowser.serverurl.SetText(controller.Settings.Settings().ServerURL)
+	settingsbrowser.form.AppendItem(NewFormItem("Server URL", settingsbrowser.serverurl))
 
-	gamedirectorybind := binding.NewString()
-	gamedirectorybind.Set(controller.Settings.Settings().GameDirectory)
-	gamedirectoryentry := widget.NewEntryWithData(gamedirectorybind)
-	settingsbrowser.form.AppendItem(NewFormItem("Game Directory", gamedirectoryentry))
+	settingsbrowser.gamedirectory.SetText(controller.Settings.Settings().GameDirectory)
+	gamedirectoryexplorer := widget.NewButtonWithIcon("", theme.FolderOpenIcon(), settingsbrowser.gamedirectoryExplorerCallback)
+	gamedirectory := container.NewBorder(nil, nil, nil, gamedirectoryexplorer, settingsbrowser.gamedirectory)
+	settingsbrowser.form.AppendItem(NewFormItem("Game Directory", gamedirectory))
 
-	usernamebind := binding.NewString()
-	usernamebind.Set(controller.Settings.Settings().Username)
-	usernameentry := widget.NewEntryWithData(usernamebind)
-	usernameentry.Validator = func(s string) error {
+	settingsbrowser.username.SetText(controller.Settings.Settings().Username)
+	settingsbrowser.username.Validator = func(s string) error {
 		match, err := regexp.MatchString("^(?:[a-zA-Z]|[0-9]|-)+$", s)
 		if !match || err != nil {
 			return errors.New("only alphanumeric characters and \"-\" allowed")
 		}
 		return nil
 	}
-	settingsbrowser.form.AppendItem(NewFormItem("Username", usernameentry))
+	settingsbrowser.form.AppendItem(NewFormItem("Username", settingsbrowser.username))
+
 	settingsbrowser.form.SetSubmitText("Save")
 	settingsbrowser.form.SetCancelText("Reset")
 	settingsbrowser.form.OnSubmit = func() {
-		serverurl, _ := serverurlbind.Get()
-		controller.Settings.SetServerURL(serverurl)
-		gamedirectory, _ := gamedirectorybind.Get()
-		controller.Settings.SetGameDirectory(gamedirectory)
-		username, _ := usernamebind.Get()
-		controller.Settings.SetUsername(username)
+		controller.Settings.SetServerURL(settingsbrowser.serverurl.Text)
+		controller.Settings.SetGameDirectory(settingsbrowser.gamedirectory.Text)
+		controller.Settings.SetUsername(settingsbrowser.username.Text)
 		err := controller.Settings.Settings().Save()
 		if err != nil {
 			controller.Status.Error("Error saving settings: "+err.Error(), 3*time.Second)
@@ -70,17 +77,55 @@ func NewSettingsBrowser(controller *controller.Controller) (settingsbrowser *Set
 		controller.Status.Info("Settings resetted", 3*time.Second)
 	}
 
-	settingsbrowser.serverurl = serverurlbind
-	settingsbrowser.gamedirectory = gamedirectorybind
-	settingsbrowser.username = usernamebind
+	controller.Settings.Subscribe(settingsbrowser.settingschanged)
+	settingsbrowser.run()
 
 	return settingsbrowser
 }
 
+func (widget *SettingsBrowser) run() {
+	widget.controller.WaitGroup().Add(1)
+	go widget.settingsUpdater()
+}
+
+func (widget *SettingsBrowser) settingsUpdater() {
+	defer widget.controller.WaitGroup().Done()
+	for {
+		select {
+		case <-widget.controller.Context().Done():
+			log.Trace().Msg("exiting SettingsBrowser settingsUpdater()")
+			return
+		case <-widget.settingschanged:
+			widget.serverurl.SetText(widget.controller.Settings.Settings().ServerURL)
+			widget.gamedirectory.SetText(widget.controller.Settings.Settings().GameDirectory)
+			widget.username.SetText(widget.controller.Settings.Settings().Username)
+			widget.Refresh()
+		}
+	}
+}
+
+func (widget *SettingsBrowser) gamedirectoryExplorerCallback() {
+	folderdialog := dialog.NewFolderOpen(func(uri fyne.ListableURI, err error) {
+		if uri == nil || err != nil {
+			return
+		}
+		widget.gamedirectory.SetText(uri.Path())
+	}, widget.window)
+
+	dialogStartURI, err := storage.ListerForURI(storage.NewFileURI(widget.controller.Settings.Settings().GameDirectory))
+	if err == nil {
+		folderdialog.SetLocation(dialogStartURI)
+	}
+
+	//This will make the folderopen dialog to be "fullscreen" inside the app
+	folderdialog.Resize(fyne.NewSize(10000, 10000))
+	folderdialog.Show()
+}
+
 func (widget *SettingsBrowser) ResetData() {
-	widget.serverurl.Set(widget.controller.Settings.Settings().ServerURL)
-	widget.gamedirectory.Set(widget.controller.Settings.Settings().GameDirectory)
-	widget.username.Set(widget.controller.Settings.Settings().Username)
+	widget.serverurl.SetText(widget.controller.Settings.Settings().ServerURL)
+	widget.gamedirectory.SetText(widget.controller.Settings.Settings().GameDirectory)
+	widget.username.SetText(widget.controller.Settings.Settings().Username)
 	widget.Refresh()
 }
 


### PR DESCRIPTION
Added a file-explorer dialog to choose a game-directory folder from in the SettingsBrowser.

Users can now pick a folder where games are stored via UI.

Fixes: https://github.com/seternate/go-lanty-client/issues/15