### PR TITLE
More intuitive settings save

### DIFF
--- a/pkg/controller/settingscontroller.go
+++ b/pkg/controller/settingscontroller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/seternate/go-lanty-client/pkg/setting"
 	"github.com/seternate/go-lanty/pkg/util"
@@ -50,6 +51,14 @@ func (controller *SettingsController) Settings() setting.Settings {
 	defer controller.mutex.RUnlock()
 	controller.mutex.RLock()
 	return *controller.settings
+}
+
+func (controller *SettingsController) Save() (err error) {
+	err = controller.Settings().Save()
+	if err != nil {
+		controller.parent.Status.Error("Error saving settings: "+err.Error(), 3*time.Second)
+	}
+	return
 }
 
 func (controller *SettingsController) Subscribe(subscriber chan struct{}) {

--- a/pkg/widget/entry.go
+++ b/pkg/widget/entry.go
@@ -1,0 +1,29 @@
+package widget
+
+import "fyne.io/fyne/v2/widget"
+
+type Entry struct {
+	widget.Entry
+
+	OnFocusChanged func(bool)
+}
+
+func NewEntry() *Entry {
+	entry := &Entry{}
+	entry.ExtendBaseWidget(entry)
+	return entry
+}
+
+func (widget *Entry) FocusGained() {
+	widget.Entry.FocusGained()
+	if widget.OnFocusChanged != nil {
+		widget.OnFocusChanged(true)
+	}
+}
+
+func (widget *Entry) FocusLost() {
+	widget.Entry.FocusLost()
+	if widget.OnFocusChanged != nil {
+		widget.OnFocusChanged(false)
+	}
+}

--- a/pkg/widget/form.go
+++ b/pkg/widget/form.go
@@ -57,6 +57,11 @@ func (widget *Form) SetSubmitText(text string) {
 	widget.Refresh()
 }
 
+func (widget *Form) HideSubmit() {
+	widget.submit.Hide()
+	widget.Refresh()
+}
+
 func (widget *Form) SetCancelText(text string) {
 	widget.cancel.SetText(text)
 	widget.Refresh()
@@ -91,11 +96,17 @@ func (renderer *formRenderer) Layout(size fyne.Size) {
 		item.Resize(fyne.NewSize(size.Width-2*theme.InnerPadding(), item.MinSize().Height))
 		lastposition = item.Position().Y + item.Size().Height
 	}
-	buttonSize := fyne.NewSize(fyne.Max(renderer.widget.cancel.MinSize().Width, renderer.widget.submit.MinSize().Width), renderer.widget.submit.MinSize().Height)
-	renderer.widget.submit.Resize(buttonSize)
-	renderer.widget.submit.Move(fyne.NewPos(size.Width-theme.InnerPadding()-buttonSize.Width, size.Height-theme.InnerPadding()-buttonSize.Height))
-	renderer.widget.cancel.Resize(buttonSize)
-	renderer.widget.cancel.Move(fyne.NewPos(renderer.widget.submit.Position().X-theme.InnerPadding()-buttonSize.Width, renderer.widget.submit.Position().Y))
+	if renderer.widget.submit.Hidden {
+		buttonSize := fyne.NewSize(renderer.widget.cancel.MinSize().Width, renderer.widget.cancel.MinSize().Height)
+		renderer.widget.cancel.Resize(buttonSize)
+		renderer.widget.cancel.Move(fyne.NewPos(size.Width-theme.InnerPadding()-buttonSize.Width, size.Height-theme.InnerPadding()-buttonSize.Height))
+	} else {
+		buttonSize := fyne.NewSize(fyne.Max(renderer.widget.cancel.MinSize().Width, renderer.widget.submit.MinSize().Width), renderer.widget.submit.MinSize().Height)
+		renderer.widget.submit.Resize(buttonSize)
+		renderer.widget.submit.Move(fyne.NewPos(size.Width-theme.InnerPadding()-buttonSize.Width, size.Height-theme.InnerPadding()-buttonSize.Height))
+		renderer.widget.cancel.Resize(buttonSize)
+		renderer.widget.cancel.Move(fyne.NewPos(renderer.widget.submit.Position().X-theme.InnerPadding()-buttonSize.Width, renderer.widget.submit.Position().Y))
+	}
 }
 
 func (renderer *formRenderer) MinSize() fyne.Size {

--- a/pkg/widget/settingbrowser.go
+++ b/pkg/widget/settingbrowser.go
@@ -106,16 +106,8 @@ func NewSettingsBrowser(controller *controller.Controller, window fyne.Window) (
 	}
 	settingsbrowser.form.AppendItem(NewFormItem("Username", settingsbrowser.username))
 
-	settingsbrowser.form.SetSubmitText("Save")
+	settingsbrowser.form.HideSubmit()
 	settingsbrowser.form.SetCancelText("Reset")
-	settingsbrowser.form.OnSubmit = func() {
-		controller.Settings.SetServerURL(settingsbrowser.serverurl.Text)
-		controller.Settings.SetGameDirectory(settingsbrowser.gamedirectory.Text)
-		controller.Settings.SetUsername(settingsbrowser.username.Text)
-		if controller.Settings.Save() == nil {
-			controller.Status.Info("Settings successfully saved", 3*time.Second)
-		}
-	}
 	settingsbrowser.form.OnCancel = func() {
 		settingsbrowser.ResetData()
 		controller.Status.Info("Settings resetted", 3*time.Second)


### PR DESCRIPTION
The Entry widget was extended by the possibility to set a function
callback if the widgets focus has changed.
This enables the user to customize the widget behaviour on focus change.

The behaviour how changed settings in the SettingsBrowser are saved was
changed. If a setting is changed it gets saved by either pressing enter
or when the widget loses focus.

The 'Save' button in the SettingsBrowser was removed. Due to the changed
save behaviour it is not neccessary.

Fixes: https://github.com/seternate/go-lanty-client/issues/12