### PR TITLE
Add File message to chat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/rs/zerolog v1.31.0
-	github.com/seternate/go-lanty v0.1.0-beta.0.20240809132204-3be3d1587bdd
+	github.com/seternate/go-lanty v0.1.0-beta.0.20240818103544-c247788a1ae4
 	golang.design/x/clipboard v0.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/seternate/go-lanty v0.1.0-beta.0.20240809132204-3be3d1587bdd h1:vb22tGtb2yVepWmO/O6qHH6Zgqo8Ztd+PK47kg3xQCU=
-github.com/seternate/go-lanty v0.1.0-beta.0.20240809132204-3be3d1587bdd/go.mod h1:QL66bV5xXhUysHVUI8VaX773dsvXJp0bDzrXWWq3IOs=
+github.com/seternate/go-lanty v0.1.0-beta.0.20240818103544-c247788a1ae4 h1:vZbd/gyKrHFOBXz4htFCNR/AxD2c8avrPFazuYtMOdk=
+github.com/seternate/go-lanty v0.1.0-beta.0.20240818103544-c247788a1ae4/go.mod h1:QL66bV5xXhUysHVUI8VaX773dsvXJp0bDzrXWWq3IOs=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/pkg/controller/settingscontroller.go
+++ b/pkg/controller/settingscontroller.go
@@ -65,6 +65,14 @@ func (controller *SettingsController) SetUsername(username string) {
 	controller.Save()
 }
 
+func (controller *SettingsController) SetDownloadDirectory(downloaddirectory string) {
+	controller.mutex.Lock()
+	controller.settings.DownloadDirectory = downloaddirectory
+	controller.mutex.Unlock()
+	controller.notifySubcriber()
+	controller.Save()
+}
+
 func (controller *SettingsController) Settings() setting.Settings {
 	defer controller.mutex.RUnlock()
 	controller.mutex.RLock()

--- a/pkg/setting/settings.go
+++ b/pkg/setting/settings.go
@@ -14,9 +14,10 @@ const (
 )
 
 type Settings struct {
-	ServerURL     string `yaml:"serverurl"`
-	GameDirectory string `yaml:"gamedirectory"`
-	Username      string `yaml:"username"`
+	ServerURL         string `yaml:"serverurl"`
+	GameDirectory     string `yaml:"gamedirectory"`
+	Username          string `yaml:"username"`
+	DownloadDirectory string `yaml:"downloaddirectory"`
 }
 
 func LoadSettings() (s *Settings, err error) {

--- a/pkg/widget/lanty.go
+++ b/pkg/widget/lanty.go
@@ -40,7 +40,7 @@ func NewLanty(controller *controller.Controller, window fyne.Window) *Lanty {
 	downloadbrowser := NewDownloadBrowser(controller)
 	userbrowser := NewUserBrowser(controller)
 	settingsbrowser := NewSettingsBrowser(controller, window)
-	chatbrowser := NewChatBrowser(controller)
+	chatbrowser := NewChatBrowser(controller, window)
 
 	lanty := &Lanty{
 		controller:      controller,

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,3 +1,4 @@
 serverurl: http://localhost:8080
 gamedirectory: extract
 username: lanty
+downloaddirectory: download


### PR DESCRIPTION
The Chat Browser can now send and receive File messages to/from the server. This enables users to share files. The files can be downloaded by clicking on the file message. A new file can be send by selecting one with the Attachment button.

Addresses: #25 