### PR TITLE
Enforce non-default username

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -7,7 +7,6 @@ changelog:
   categories:
     - title: Breaking Changes 🛠
       labels:
-        - feature
         - breaking-change
     - title: New Features 🎉
       labels:

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/rs/zerolog v1.31.0
-	github.com/seternate/go-lanty v0.1.0-beta.0.20240818103544-c247788a1ae4
+	github.com/seternate/go-lanty v0.2.0
 	golang.design/x/clipboard v0.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/seternate/go-lanty v0.1.0-beta.0.20240818103544-c247788a1ae4 h1:vZbd/gyKrHFOBXz4htFCNR/AxD2c8avrPFazuYtMOdk=
-github.com/seternate/go-lanty v0.1.0-beta.0.20240818103544-c247788a1ae4/go.mod h1:QL66bV5xXhUysHVUI8VaX773dsvXJp0bDzrXWWq3IOs=
+github.com/seternate/go-lanty v0.2.0 h1:Oj/ubPDZOvJerYcsCZXkiHQpXyzAZkcvpS+keiYrTTU=
+github.com/seternate/go-lanty v0.2.0/go.mod h1:QL66bV5xXhUysHVUI8VaX773dsvXJp0bDzrXWWq3IOs=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/pkg/setting/settings.go
+++ b/pkg/setting/settings.go
@@ -10,7 +10,8 @@ import (
 const (
 	APPLICATION_NAME = "Lanty"
 	SETTINGS_PATH    = "settings.yaml"
-	VERSION          = "v0.1.0-beta"
+	VERSION          = "v0.2.0"
+	DEFAULT_USERNAME = "lanty"
 )
 
 type Settings struct {

--- a/pkg/widget/defaultusernamebrowser.go
+++ b/pkg/widget/defaultusernamebrowser.go
@@ -1,0 +1,76 @@
+package widget
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	fynetheme "fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+	"github.com/seternate/go-lanty-client/pkg/controller"
+)
+
+type DefaultUsernameBrowser struct {
+	widget.BaseWidget
+
+	controller *controller.Controller
+
+	settingsbrowser *SettingsBrowser
+}
+
+func NewDefaultUsernameBrowser(controller *controller.Controller, window fyne.Window) (browser *DefaultUsernameBrowser) {
+	browser = &DefaultUsernameBrowser{
+		controller:      controller,
+		settingsbrowser: NewSettingsBrowser(controller, window),
+	}
+	browser.ExtendBaseWidget(browser)
+
+	return
+}
+
+func (widget *DefaultUsernameBrowser) SetOnSubmit(onSubmit func()) {
+	widget.settingsbrowser.SetOnSubmit(onSubmit)
+}
+
+func (widget *DefaultUsernameBrowser) CreateRenderer() fyne.WidgetRenderer {
+	return newDefaulusernamebrowserRenderer(widget)
+}
+
+type defaultusernamebrowserRenderer struct {
+	widget     *DefaultUsernameBrowser
+	background *canvas.Rectangle
+}
+
+func newDefaulusernamebrowserRenderer(widget *DefaultUsernameBrowser) *defaultusernamebrowserRenderer {
+	renderer := &defaultusernamebrowserRenderer{
+		widget:     widget,
+		background: canvas.NewRectangle(fynetheme.BackgroundColor()),
+	}
+
+	return renderer
+}
+
+func (renderer *defaultusernamebrowserRenderer) Objects() []fyne.CanvasObject {
+	objects := []fyne.CanvasObject{
+		renderer.background,
+		renderer.widget.settingsbrowser,
+	}
+
+	return objects
+}
+
+func (renderer *defaultusernamebrowserRenderer) Layout(size fyne.Size) {
+	renderer.background.Move(fyne.NewPos(0, 0))
+	renderer.background.Resize(size)
+	renderer.widget.settingsbrowser.Move(fyne.NewPos(0, 0))
+	renderer.widget.settingsbrowser.Resize(size)
+}
+
+func (renderer *defaultusernamebrowserRenderer) MinSize() fyne.Size {
+	return renderer.widget.settingsbrowser.MinSize()
+}
+
+func (renderer *defaultusernamebrowserRenderer) Refresh() {
+	renderer.background.Refresh()
+	renderer.widget.settingsbrowser.Refresh()
+}
+
+func (renderer *defaultusernamebrowserRenderer) Destroy() {}

--- a/pkg/widget/form.go
+++ b/pkg/widget/form.go
@@ -62,6 +62,11 @@ func (widget *Form) HideSubmit() {
 	widget.Refresh()
 }
 
+func (widget *Form) ShowSubmit() {
+	widget.submit.Show()
+	widget.Refresh()
+}
+
 func (widget *Form) SetCancelText(text string) {
 	widget.cancel.SetText(text)
 	widget.Refresh()


### PR DESCRIPTION
The user is enforced to set a non-default username (default: lanty). This is done by the following methods:
1) The application starts with the SettingsBrowser, when the default
   username is still set at application start.
2) The user can not set and save the default username in the
   SettingsBrowser view.

Fixes https://github.com/seternate/go-lanty-client/issues/7